### PR TITLE
Potential fix for code scanning alert no. 16: DOM text reinterpreted as HTML

### DIFF
--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -9,7 +9,8 @@
     "lib": "workspace:*",
     "dialog-polyfill": "0.5.6",
     "lichess-pgn-viewer": "^2.4.0",
-    "tablesort": "^5.3.0"
+    "tablesort": "^5.3.0",
+    "he": "^1.2.0"
   },
   "build": {
     "bundle": [

--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -3,6 +3,7 @@ import { text as xhrText } from 'lib/xhr';
 import { requestIdleCallback, $as } from 'lib';
 import { spinnerHtml } from 'lib/controls';
 import { pubsub } from 'lib/pubsub';
+import * as he from 'he';
 
 // Thanks Steven Benner! - adapted from https://github.com/stevenbenner/jquery-powertip
 
@@ -57,7 +58,7 @@ const imagePowertip = (el: HTMLElement) =>
       preRender: (el: HTMLElement) => {
         const w = el.dataset.width ? ` width="${el.dataset.width}"` : '';
         const h = el.dataset.height ? ` height="${el.dataset.height}"` : '';
-        document.querySelector('#image-powertip')!.innerHTML = `<img src="${el.dataset.src}"${w}${h}>`;
+        document.querySelector('#image-powertip')!.innerHTML = `<img src="${he.escape(el.dataset.src)}"${w}${h}>`;
       },
       popupId: 'image-powertip',
       placement: 's',


### PR DESCRIPTION
Potential fix for [https://github.com/securityuniverse/lila/security/code-scanning/16](https://github.com/securityuniverse/lila/security/code-scanning/16)

To fix the problem, we need to ensure that the value of `el.dataset.src` is properly sanitized or escaped before being inserted into the HTML string. The best way to do this is to use a library that provides functions for escaping HTML characters. One such library is `he` (HTML entities), which can be used to escape the value of `el.dataset.src`.

1. Install the `he` library if it is not already installed.
2. Import the `he` library in the file.
3. Use the `he.escape` function to escape the value of `el.dataset.src` before inserting it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
